### PR TITLE
Added no compression to binary function.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.o
+deps/
+ebin/
+logs/
+perf/hh
+priv
+.rebar
+*.beam

--- a/c_src/hdr_histogram_bin.c
+++ b/c_src/hdr_histogram_bin.c
@@ -182,16 +182,15 @@ int hdr_decode(
     }
 
     _compression_flyweight* compression_flyweight = (_compression_flyweight*) buffer;
-    switch be32toh(compression_flyweight->cookie) {
-      case NOCOMPRESSION_COOKIE:
-        result = hdr_decode_uncompressed(buffer, length, histogram);
-        break;
-      case COMPRESSION_COOKIE:
-        result = hdr_decode_compressed(buffer, length, histogram);
-        break;
-      default:
-        FAIL_AND_CLEANUP(cleanup, result, HDR_COMPRESSION_COOKIE_MISMATCH);
-      }
+
+    int32_t cookie = be32toh(compression_flyweight->cookie);
+    if (cookie == NOCOMPRESSION_COOKIE) {
+      result = hdr_decode_uncompressed(buffer, length, histogram);
+    } else if (cookie == COMPRESSION_COOKIE) {
+      result = hdr_decode_compressed(buffer, length, histogram);
+    } else {
+      FAIL_AND_CLEANUP(cleanup, result, HDR_COMPRESSION_COOKIE_MISMATCH);
+    }
 
  cleanup:
 

--- a/c_src/hdr_histogram_bin.c
+++ b/c_src/hdr_histogram_bin.c
@@ -1,0 +1,272 @@
+/**
+ * hdr_histogram.c
+ * Written by Michael Barker and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ */
+
+#define _GNU_SOURCE
+#include <stdlib.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <zlib.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <ctype.h>
+#include <math.h>
+#include <time.h>
+
+#include "hdr_histogram.h"
+#include "hdr_histogram_bin.h"
+#include "hdr_histogram_log.h"
+
+#ifdef __APPLE__
+
+#include <libkern/OSByteOrder.h>
+
+#define htobe16(x) OSSwapHostToBigInt16(x)
+#define htole16(x) OSSwapHostToLittleInt16(x)
+#define be16toh(x) OSSwapBigToHostInt16(x)
+#define le16toh(x) OSSwapLittleToHostInt16(x)
+
+#define htobe32(x) OSSwapHostToBigInt32(x)
+#define htole32(x) OSSwapHostToLittleInt32(x)
+#define be32toh(x) OSSwapBigToHostInt32(x)
+#define le32toh(x) OSSwapLittleToHostInt32(x)
+
+#define htobe64(x) OSSwapHostToBigInt64(x)
+#define htole64(x) OSSwapHostToLittleInt64(x)
+#define be64toh(x) OSSwapBigToHostInt64(x)
+#define le64toh(x) OSSwapLittleToHostInt64(x)
+
+#elif __linux__
+
+#include <endian.h>
+
+#else
+
+#warning "Platform not supported\n"
+
+#endif
+
+#define FAIL_AND_CLEANUP(label, error_name, error) \
+    do                      \
+    {                       \
+        error_name = error; \
+        goto label;         \
+    }                       \
+    while (0)
+
+enum zero_strategy { ZERO_ALL, ZERO_NONE };
+
+
+// ######## ##    ##  ######   #######  ########  #### ##    ##  ######
+// ##       ###   ## ##    ## ##     ## ##     ##  ##  ###   ## ##    ##
+// ##       ####  ## ##       ##     ## ##     ##  ##  ####  ## ##
+// ######   ## ## ## ##       ##     ## ##     ##  ##  ## ## ## ##   ####
+// ##       ##  #### ##       ##     ## ##     ##  ##  ##  #### ##    ##
+// ##       ##   ### ##    ## ##     ## ##     ##  ##  ##   ### ##    ##
+// ######## ##    ##  ######   #######  ########  #### ##    ##  ######
+
+static const int32_t ENCODING_COOKIE      = 0x1c849308 + (8 << 4);
+static const int32_t COMPRESSION_COOKIE   = 0x1c849309 + (8 << 4);
+static const int32_t NOCOMPRESSION_COOKIE = 0x1c84930A + (8 << 4);
+
+typedef struct __attribute__((__packed__))
+{
+    int32_t cookie;
+    int32_t significant_figures;
+    int64_t lowest_trackable_value;
+    int64_t highest_trackable_value;
+    int64_t total_count;
+    int64_t counts[0];
+} _encoding_flyweight;
+
+typedef struct __attribute__((__packed__))
+{
+    int32_t cookie;
+    int32_t length;
+    uint8_t data[0];
+} _compression_flyweight;
+
+int hdr_encode_uncompressed(
+    struct hdr_histogram* h,
+    uint8_t** compressed_histogram,
+    int* compressed_len)
+{
+  //const int counts_per_chunk = 512;
+  //int64_t chunk[counts_per_chunk];
+
+    uint8_t* buf = NULL;
+    int idx = sizeof(_compression_flyweight);
+    int len = 4096;
+
+    int result = 0;
+
+    if ((buf = (uint8_t*) malloc(len * sizeof(uint8_t))) == NULL)
+    {
+        FAIL_AND_CLEANUP(cleanup, result, ENOMEM);
+    }
+
+    _compression_flyweight* comp_fw = (_compression_flyweight*) buf;
+    _encoding_flyweight encode_fw;
+
+    encode_fw.cookie                  = htobe32(ENCODING_COOKIE);
+    encode_fw.significant_figures     = htobe32(h->significant_figures);
+    encode_fw.lowest_trackable_value  = htobe64(h->lowest_trackable_value);
+    encode_fw.highest_trackable_value = htobe64(h->highest_trackable_value);
+    encode_fw.total_count             = htobe64(h->total_count);
+
+    //int counts_index = 0;
+
+    memcpy(buf+idx, &encode_fw, sizeof(_encoding_flyweight));
+    idx += sizeof(_encoding_flyweight);
+
+
+    for (int i = 0; i < h->counts_len; i++)
+    {
+
+      if (idx + sizeof(uint64_t) > len) {
+        int new_len = len * 2;
+        uint8_t* new_buf = (uint8_t*) realloc(buf, new_len * sizeof(uint8_t));
+        if (NULL == new_buf)
+          {
+            FAIL_AND_CLEANUP(cleanup, result, ENOMEM);
+          }
+        buf = new_buf;
+        len = new_len;
+
+      }
+      buf[idx] = htobe64(h->counts[i]);
+      idx += sizeof(uint64_t);
+    }
+    uint8_t* new_buf = (uint8_t*) malloc(idx * sizeof(uint8_t));
+    if (NULL == new_buf)
+      {
+        FAIL_AND_CLEANUP(cleanup, result, ENOMEM);
+      }
+    memcpy(new_buf, buf, idx);
+    free(buf);
+    comp_fw = (_compression_flyweight*) new_buf;
+    comp_fw->cookie = htobe32(NOCOMPRESSION_COOKIE);
+    comp_fw->length = htobe32(idx);
+    *compressed_histogram = new_buf;
+    *compressed_len = idx;
+
+cleanup:
+    if (result != 0)
+    {
+        free(buf);
+    }
+
+    return result;
+}
+
+// ########  ########  ######   #######  ########  #### ##    ##  ######
+// ##     ## ##       ##    ## ##     ## ##     ##  ##  ###   ## ##    ##
+// ##     ## ##       ##       ##     ## ##     ##  ##  ####  ## ##
+// ##     ## ######   ##       ##     ## ##     ##  ##  ## ## ## ##   ####
+// ##     ## ##       ##       ##     ## ##     ##  ##  ##  #### ##    ##
+// ##     ## ##       ##    ## ##     ## ##     ##  ##  ##   ### ##    ##
+// ########  ########  ######   #######  ########  #### ##    ##  ######
+
+int hdr_decode(
+    uint8_t* buffer, size_t length, struct hdr_histogram** histogram)
+{
+    int result = 0;
+
+    if (length < sizeof(_compression_flyweight))
+    {
+        FAIL_AND_CLEANUP(cleanup, result, EINVAL);
+    }
+
+    _compression_flyweight* compression_flyweight = (_compression_flyweight*) buffer;
+    switch be32toh(compression_flyweight->cookie) {
+      case NOCOMPRESSION_COOKIE:
+        result = hdr_decode_uncompressed(buffer, length, histogram);
+        break;
+      case COMPRESSION_COOKIE:
+        result = hdr_decode_compressed(buffer, length, histogram);
+        break;
+      default:
+        FAIL_AND_CLEANUP(cleanup, result, HDR_COMPRESSION_COOKIE_MISMATCH);
+      }
+
+ cleanup:
+
+    return result;
+
+}
+
+int hdr_decode_uncompressed(
+    uint8_t* buffer, size_t length, struct hdr_histogram** histogram)
+{
+    int64_t* counts_array;
+    struct hdr_histogram* h = NULL;
+    int result = 0;
+
+    int64_t counts_tally = 0;
+
+    if (length < sizeof(_compression_flyweight))
+    {
+        FAIL_AND_CLEANUP(cleanup, result, EINVAL);
+    }
+
+
+    _compression_flyweight* compression_flyweight = (_compression_flyweight*) buffer;
+    _encoding_flyweight encoding_flyweight;
+
+    if (NOCOMPRESSION_COOKIE != be32toh(compression_flyweight->cookie))
+    {
+        FAIL_AND_CLEANUP(cleanup, result, HDR_COMPRESSION_COOKIE_MISMATCH);
+    }
+
+    memcpy((void*) &encoding_flyweight, compression_flyweight->data, sizeof(_encoding_flyweight));
+    counts_array = (int64_t *) (compression_flyweight->data + sizeof(_encoding_flyweight));
+
+    if (ENCODING_COOKIE != be32toh(encoding_flyweight.cookie))
+    {
+        FAIL_AND_CLEANUP(cleanup, result, HDR_ENCODING_COOKIE_MISMATCH);
+    }
+
+    int64_t lowest_trackable_value = be64toh(encoding_flyweight.lowest_trackable_value);
+    int64_t highest_trackable_value = be64toh(encoding_flyweight.highest_trackable_value);
+    int32_t significant_figures = be32toh(encoding_flyweight.significant_figures);
+
+    if (hdr_init(
+        lowest_trackable_value,
+        highest_trackable_value,
+        significant_figures,
+        &h) != 0)
+    {
+        FAIL_AND_CLEANUP(cleanup, result, ENOMEM);
+    }
+
+    h->total_count = be64toh(encoding_flyweight.total_count);
+
+    int counts_index = 0;
+    int available_counts = 0;
+    for (int i = 0; i < available_counts && counts_index < h->counts_len; i++)
+      {
+        h->counts[counts_index++] = be64toh(counts_array[i]);
+        counts_tally += h->counts[counts_index - 1];
+      }
+cleanup:
+
+    if (result != 0)
+    {
+        free(h);
+    }
+    else if (NULL == *histogram)
+    {
+        *histogram = h;
+    }
+    else
+    {
+        hdr_add(*histogram, h);
+        free(h);
+    }
+
+    return result;
+}

--- a/c_src/hdr_histogram_bin.h
+++ b/c_src/hdr_histogram_bin.h
@@ -1,0 +1,29 @@
+/**
+ * hdr_histogram_log.h
+ * Written by Michael Barker and released to the public domain,
+ * as explained at http://creativecommons.org/publicdomain/zero/1.0/
+ *
+ * This code follows the Plan 9 approach to header declaration.  In order
+ * to maintain fast builds does not define it's dependent headers.
+ * They should be included manually by the user.  This code requires:
+ *
+ * - #include <stdint.h>
+ * - #include <stdbool.h>
+ * - #include <stdio.h>
+ * - #include <time.h>
+ *
+ * The source for the hdr_histogram utilises a few C99 constructs, specifically
+ * the use of stdint/stdbool and inline variable declaration.
+ *
+ * The implementation makes use of zlib to provide compression.  You will need
+ * to link against -lz in order to link applications that include this header.
+ */
+
+#ifndef HDR_HISTOGRAM_H_BIN
+#define HDR_HISTOGRAM_H_BIN 1
+
+int hdr_decode(uint8_t* b, size_t len, struct hdr_histogram** h);
+int hdr_encode_uncompressed(struct hdr_histogram* h, uint8_t** ch, int* len);
+int hdr_decode_uncompressed(uint8_t* b, size_t len, struct hdr_histogram** h);
+
+#endif

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,7 @@
       "c_src/hdr_histogram_nif.c"
       , "c_src/hdr_histogram.c"
       , "c_src/hdr_histogram_log.c"
+      , "c_src/hdr_histogram_bin.c"
     ]}
 ]}.
 

--- a/src/hdr_histogram.erl
+++ b/src/hdr_histogram.erl
@@ -97,6 +97,7 @@
 -export([close/1]).
 -export([from_binary/1]).
 -export([to_binary/1]).
+-export([to_binary/2]).
 -export([iter_open/1]).
 -export([iter_init/3]).
 -export([iter_next/1]).
@@ -303,6 +304,25 @@ from_binary(_Binary) ->
 %% @doc Take a snapshot of HDR histogram internal state as a compressed binary. The reference HDR instance can be modified after a snapshot is taken in the usual way with no restrictions.
 to_binary(_Ref) ->
     erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+-spec to_binary_uncompressed(Ref) -> binary() | {error,term()} when
+    Ref :: ref().
+to_binary_uncompressed(_Ref) ->
+    erlang:nif_error({nif_not_loaded, ?MODULE}).
+
+-spec to_binary(Ref, [{compression, none} |
+                      {compression, zlib}]) ->
+                       binary() | {error,term()} when
+      Ref :: ref().
+
+to_binary(Ref, []) ->
+    to_binary(Ref);
+to_binary(Ref, [{compression, zlib}]) ->
+    to_binary(Ref);
+to_binary(Ref, [{compression, none}]) ->
+    to_binary_uncompressed(Ref);
+to_binary(_Ref, _) ->
+    {error, bad_options}.
 
 %% @private
 iter_open(_) ->

--- a/test/hdr_histogram_SUITE.erl
+++ b/test/hdr_histogram_SUITE.erl
@@ -22,6 +22,7 @@
 -export([t_hdr_reset/1]).
 -export([t_hdr_close/1]).
 -export([t_hdr_binary/1]).
+-export([t_hdr_binary_nc/1]).
 -export([t_iter_recorded/1]).
 -export([t_iter_linear/1]).
 -export([t_iter_logarithmic/1]).
@@ -47,7 +48,8 @@ groups() ->
       , t_hdr_percentiles
       , t_hdr_reset
       , t_hdr_close
-      %% , t_hdr_binary Commented out. Issues arize when used with CT
+                %%, t_hdr_binary    %% Commented out. Issues arize when used with CT
+                %%, t_hdr_binary_nc %% Commented out. Issues arize when used with CT
     ]},
      {iter, [], [
         t_iter_recorded
@@ -170,6 +172,23 @@ t_hdr_binary(Config) ->
     cmp(1.0e8 , hdr_histogram:percentile(Cor, 100.0), 0.001),
     cmp(1.0e8 , hdr_histogram:percentile(Cor2, 100.0), 0.001),
     ok.
+
+t_hdr_binary_nc(Config) ->
+    Raw = ?config(raw,Config),
+    Cor = ?config(cor,Config),
+    BinRaw = hdr_histogram:to_binary(Raw, [{compression, none}]),
+    BinCor = hdr_histogram:to_binary(Cor, [{compression, none}]),
+    true = is_binary(BinRaw),
+    true = is_binary(BinCor),
+    {ok,Raw2} = hdr_histogram:from_binary(BinRaw),
+    {ok,Cor2} = hdr_histogram:from_binary(BinRaw),
+    {error,bad_hdr_binary} = (catch hdr_histogram:from_binary(<<>>)),
+    cmp(1.0e8 , hdr_histogram:percentile(Raw, 100.0), 0.001),
+    cmp(1.0e8 , hdr_histogram:percentile(Raw2, 100.0), 0.001),
+    cmp(1.0e8 , hdr_histogram:percentile(Cor, 100.0), 0.001),
+    cmp(1.0e8 , hdr_histogram:percentile(Cor2, 100.0), 0.001),
+    ok.
+
 
 t_iter_recorded(Config) ->
     Raw = ?config(raw,Config),


### PR DESCRIPTION
This adds a new function `to_binary/2` where the second argument is a a option list, currently the available options list with:

`[{compression, none} |{compression, zlib}]`

The data structures used is the same as for the normal to binary it uses the compression cookie to indicate if it's zlib or no compression. This will gracefully fail with `HDR_COMPRESSION_COOKIE_MISMATCH` when used with the standard implementation. 

In addition the from_binary function now calls hdr_decode (instead of hdr_decode_compressed) which dispatches based on the cookie how to decode the data.

This implementation allows to add different encoders down the line by using the cookie to determine the compression used.
