### PR TITLE
Fix hdr_histogram:add/2 doc

### DIFF
--- a/doc/hdr_histogram.md
+++ b/doc/hdr_histogram.md
@@ -142,12 +142,12 @@ expected interval for correction for coordinated ommission.</td></tr><tr><td val
 
 
 <pre><code>
-add(To, From) -&gt; ok | {error, Reason}
+add(To, From) -&gt; integer() | {error, Reason}
 </code></pre>
 
 <ul class="definitions"><li><code>To = <a href="#type-ref">ref()</a></code></li><li><code>From = <a href="#type-ref">ref()</a></code></li><li><code>Reason = term()</code></li></ul>
 
-Contribute the data points from a HDR histogram to another
+Contribute the data points from a HDR histogram to another. Return the number of dropped data point values. That is, the values from From that are higher than the HighestTrackableValue of To.
 <a name="close-1"></a>
 
 ### close/1 ###

--- a/src/hdr_histogram.erl
+++ b/src/hdr_histogram.erl
@@ -168,11 +168,14 @@ record_corrected(_Ref,_Value,_ExpectedInterval) ->
 record_many(_Ref,_Value,_Count) ->
     erlang:nif_error({nif_not_loaded, ?MODULE}).
 
--spec add(To,From) -> ok | {error,Reason}  when
+-spec add(To,From) -> integer() | {error,Reason}  when
     To :: ref(),
     From :: ref(),
     Reason :: term().
-%% @doc Contribute the data points from a HDR histogram to another
+%% @doc Contribute the data points from a HDR histogram to another.
+%% Return the number of dropped data point values.
+%% That is, the values from `From' that are higher than the
+%% `HighestTrackableValue' of `To'.
 add(_ToRef,_FromRef) ->
     erlang:nif_error({nif_not_loaded, ?MODULE}).
 


### PR DESCRIPTION
hdr_histogram:add/2 returns the number of dropped values, not 'ok' as documented.
