### PR TITLE
Don't keep resources.

### DIFF
--- a/c_src/hdr_histogram_nif.c
+++ b/c_src/hdr_histogram_nif.c
@@ -168,7 +168,6 @@ ERL_NIF_TERM _hh_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     ErlNifResourceType* ctx_type = (ErlNifResourceType*)enif_priv_data(env);
     hh_ctx_t* ctx = (hh_ctx_t*)enif_alloc_resource(ctx_type, sizeof(hh_ctx_t));
-    enif_keep_resource(ctx);
 
     ctx->data = raw_histogram; 
     ctx->highest_trackable_value = highest_trackable_value;
@@ -744,7 +743,6 @@ ERL_NIF_TERM _hh_from_binary(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[]
 
     ErlNifResourceType* ctx_type = (ErlNifResourceType*)enif_priv_data(env);
     hh_ctx_t* ctx = (hh_ctx_t*)enif_alloc_resource(ctx_type, sizeof(hh_ctx_t));
-    enif_keep_resource(ctx);
 
     ctx->data = (hdr_histogram_t*)target;
     ctx->highest_trackable_value = target->highest_trackable_value;
@@ -925,7 +923,6 @@ ERL_NIF_TERM _hi_open(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
     ErlNifResourceType* ctx_type = (ErlNifResourceType*)enif_priv_data(env);
     hi_ctx_t* ctx = (hi_ctx_t*)enif_alloc_resource(ctx_type, sizeof(hi_ctx_t));
-    enif_keep_resource(ctx);
 
     ctx->type = iterator_type;
     ctx->opts = NULL;


### PR DESCRIPTION
enif_alloc_resource increments the ref count,
enif_keep_resource increments the ref count,
enif_make_resource increments the ref count,
enif_release_resource decrements the ref count.

This means the resources have a ref count of 2
at the end of these functions when they should
have a ref count of 1 (being owned solely by the
term returned from enif_make_resource).

(I have no idea how to write a test for this, but presumably if the extra reference were necessary something would have segfaulted in one of the tests that call `hdr_histogram:close/1`.)
