### PR TITLE
Add support for compilation through rebar3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ priv
 .eqc-info
 current_counterexample.eqc
 erl_crash.dump
+_build

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Darach Ennis    <darach at gmail dot com>
 Heinz Gies      <heinz at licenser dot net>
+Jesper Louis Andersen <jesper.louis.andersen at gmail dot com>
 Michael Barker
 David Reid

--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -1,0 +1,74 @@
+# Based on c_src.mk from erlang.mk by Loic Hoguin <essen@ninenines.eu>
+
+CURDIR := $(shell pwd)
+BASEDIR := $(abspath $(CURDIR)/..)
+
+PROJECT ?= $(notdir $(BASEDIR))
+PROJECT := $(strip $(PROJECT))
+
+ERTS_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s/erts-~s/include/\", [code:root_dir(), erlang:system_info(version)]).")
+ERL_INTERFACE_INCLUDE_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, include)]).")
+ERL_INTERFACE_LIB_DIR ?= $(shell erl -noshell -s init stop -eval "io:format(\"~s\", [code:lib_dir(erl_interface, lib)]).")
+
+C_SRC_DIR = $(CURDIR)
+C_SRC_OUTPUT ?= $(CURDIR)/../priv/hdr_histogram_nif.so
+
+# System type and C compiler/flags.
+
+UNAME_SYS := $(shell uname -s)
+ifeq ($(UNAME_SYS), Darwin)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch x86_64 -Wall
+	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+else ifeq ($(UNAME_SYS), FreeBSD)
+	CC ?= cc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -Wall
+else ifeq ($(UNAME_SYS), Linux)
+	CC ?= gcc
+	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -Wall
+endif
+
+CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+LDFLAGS += -shared
+
+# Verbosity.
+
+c_verbose_0 = @echo " C     " $(?F);
+c_verbose = $(c_verbose_$(V))
+
+cpp_verbose_0 = @echo " CPP   " $(?F);
+cpp_verbose = $(cpp_verbose_$(V))
+
+link_verbose_0 = @echo " LD    " $(@F);
+link_verbose = $(link_verbose_$(V))
+
+SOURCES := $(shell find $(C_SRC_DIR) -type f \( -name "*.c" -o -name "*.C" -o -name "*.cc" -o -name "*.cpp" \))
+OBJECTS = $(addsuffix .o, $(basename $(SOURCES)))
+
+COMPILE_C = $(c_verbose) $(CC) $(CFLAGS) $(CPPFLAGS) -c
+COMPILE_CPP = $(cpp_verbose) $(CXX) $(CXXFLAGS) $(CPPFLAGS) -c
+
+$(C_SRC_OUTPUT): $(OBJECTS)
+	@mkdir -p $(BASEDIR)/priv/
+	$(link_verbose) $(CC) $(OBJECTS) $(LDFLAGS) $(LDLIBS) -o $(C_SRC_OUTPUT)
+
+%.o: %.c
+	$(COMPILE_C) $(OUTPUT_OPTION) $<
+
+%.o: %.cc
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.C
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+%.o: %.cpp
+	$(COMPILE_CPP) $(OUTPUT_OPTION) $<
+
+clean:
+	@rm -f $(C_SRC_OUTPUT) $(OBJECTS)

--- a/rebar.config
+++ b/rebar.config
@@ -40,3 +40,6 @@
 {port_env, [
   {"CFLAGS", "$CFLAGS -O3 -std=c99"}
 ]}.
+
+{pre_hooks, [{"(linux|darwin|solaris)", compile, "make -C c_src"}]}.
+{post_hooks, [{"(linux|darwin|solaris)", clean, "make -C c_src clean"}]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,0 +1,8 @@
+[{<<"fqc">>,
+  {git,"https://github.com/project-fifo/fqc.git",
+       {ref,"ad62f8121414ed026a6a9f564b1856191ab7d1fc"}},
+  0},
+ {<<"edown">>,
+  {git,"https://github.com/uwiger/edown.git",
+       {ref,"b7c8eb0ac1859f8fce11cbfe3526f5ec83194776"}},
+  0}].


### PR DESCRIPTION
Add the necessary pre/post hooks for rebar3 into the rebar.config file.
Then provide a makefile which outputs the same .so as the rebar 2 variant.

This passes all 18 Common Test cases if run through `rebar3 ct` as expected. I have not run the EQC test suite. Otherwise, things seems to work as expected.
