### PR TITLE
GCC < 4.4 and glibc < 2.9 compatibility

### DIFF
--- a/c_src/hdr_histogram.c
+++ b/c_src/hdr_histogram.c
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <stdbool.h>
 #include <math.h>
-#include <x86intrin.h>
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>

--- a/c_src/hdr_histogram_log.c
+++ b/c_src/hdr_histogram_log.c
@@ -43,6 +43,36 @@
 
 #include <endian.h>
 
+/* GLIBC < 2.9 */
+#include <byteswap.h>
+# if __BYTE_ORDER == __LITTLE_ENDIAN
+#  ifndef htobe32
+#    define htobe32(x) bswap_32 (x)
+#  endif
+#  ifndef be32toh
+#    define be32toh(x) bswap_32 (x)
+#  endif
+#  ifndef htobe64
+#    define htobe64(x) bswap_64 (x)
+#  endif
+#  ifndef be64toh
+#    define be64toh(x) bswap_64 (x)
+#   endif
+# else
+#  ifndef htobe32
+#    define htobe32(x) (x)
+#  endif
+#  ifndef be32toh
+#    define be32toh(x) (x)
+#  endif
+#  ifndef htobe64
+#    define htobe64(x) (x)
+#  endif
+#  ifndef be64toh
+#    define be64toh(x) (x)
+#   endif
+# endif
+
 #elif __sun__
 
 #include "byteorder.h"


### PR DESCRIPTION
I tried to compile hdr_histogram_erl on Centos 5 and had some problems with missing header files and functions.
Maybe this could save someone's time when dealing with legacy environments.
