### PR TITLE
Fix nif unload function

### DIFF
--- a/c_src/hdr_histogram_nif.c
+++ b/c_src/hdr_histogram_nif.c
@@ -1411,7 +1411,7 @@ static void on_unload(ErlNifEnv* env, void *priv_data)
 {
     if (priv_data != NULL)
     {
-       free(priv_data);
+       enif_free(priv_data);
     }
 }
 


### PR DESCRIPTION
nif_free() should be used instead of free()
because memory was allocated by nif_alloc
It may lead to erlang vm crash on hdr_histogram
module code purge
