### PR TITLE
Fix Elixir Example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ priv
 current_counterexample.eqc
 erl_crash.dump
 _build
+*.hgrm

--- a/README.md
+++ b/README.md
@@ -86,45 +86,7 @@ main(_) ->
     io:format("Done!\n").
 ```
 
-The same library works with other BEAM hosted languages, such as Elixir:
-
-```elixir
-#
-# Simple histogram capture example using Elixir
-#
-
-defmodule Simple do
-    def main do
-        # Create a fresh HDR histogram instance
-            {:ok,r} = :hdr_histogram.open(10000000,3)
-
-            # record a random uniform distribution of 1M data points
-        for n <- 1..1000000, do: :hdr_histogram.record(r,:random.uniform(n))
-
-        # print percentiles to stdout as CLASSIC
-        :hdr_histogram.print(r,:classic)
-
-        # log percentiles to file as CSV
-        # ELIXIR BUG :hdr_histogram.log(r,:csv,"elixir.hgrm")
-
-        # print other values
-        IO.puts "Min #{:hdr_histogram.min(r)}"
-        IO.puts "Mean #{:hdr_histogram.mean(r)}"
-        IO.puts "Median #{:hdr_histogram.median(r)}"
-        IO.puts "Max #{:hdr_histogram.max(r)}"
-        IO.puts "Stddev #{:hdr_histogram.stddev(r)}"
-        IO.puts "99ile #{:hdr_histogram.percentile(r,99.0)}"
-        IO.puts "99.9999ile #{:hdr_histogram.percentile(r,99.9999)}"
-        IO.puts "Memory Size #{:hdr_histogram.get_memory_size(r)}"
-        IO.puts "Total Count #{:hdr_histogram.get_total_count(r)}"
-
-        # we're done, cleanup any held resources
-        :hdr_histogram.close(r)
-
-        IO.puts "Done!"
-        end
-end
-```
+The same library works with other BEAM hosted languages, such as Elixir. See `examples/simple.exs`.
 
 [API documentation](doc/README.md)
 

--- a/examples/simple.exs
+++ b/examples/simple.exs
@@ -1,35 +1,55 @@
+# Run with elixir -pa ./ebin examples/simple.exs
+
 #
 # Simple histogram capture example using Elixir
 #
-
 defmodule Simple do
-    def main do
-        # Create a fresh HDR histogram instance
-            {:ok,r} = :hdr_histogram.open(10000000,3)
+  def main do
+    # create a fresh HDR histogram instance
+    {:ok, ref} = :hdr_histogram.open(1000000, 3)
 
-            # record a random uniform distribution of 1M data points
-        for n <- 1..1000000, do: :hdr_histogram.record(r,:random.uniform(n))
+    n = 10000000
 
-        # print percentiles to stdout as CLASSIC
-        :hdr_histogram.print(r,:classic)
+    # record a random uniform distribution of 1M data points
+    started = :os.timestamp
+    loop(ref, n)
+    ended = :os.timestamp
 
-        # log percentiles to file as CSV
-        # ELIXIR BUG :hdr_histogram.log(r,:csv,"elixir.hgrm")
+    duration = :timer.now_diff(ended, started) / 1.0e6
+    rate = case duration > 1 do
+       true -> n/duration
+       false -> n*duration
+    end
+    :io.format("Runtime: ~psecs ~.5frps~n", [duration, rate])
 
-        # print other values
-        IO.puts "Min #{:hdr_histogram.min(r)}"
-        IO.puts "Mean #{:hdr_histogram.mean(r)}"
-        IO.puts "Median #{:hdr_histogram.median(r)}"
-        IO.puts "Max #{:hdr_histogram.max(r)}"
-        IO.puts "Stddev #{:hdr_histogram.stddev(r)}"
-        IO.puts "99ile #{:hdr_histogram.percentile(r,99.0)}"
-        IO.puts "99.9999ile #{:hdr_histogram.percentile(r,99.9999)}"
-        IO.puts "Memory Size #{:hdr_histogram.get_memory_size(r)}"
-        IO.puts "Total Count #{:hdr_histogram.get_total_count(r)}"
+    # print percentiles to stdout as CSV
+    :hdr_histogram.print(ref, :csv)
 
-        # we're done, cleanup any held resources
-        :hdr_histogram.close(r)
+    # log percentiles to file as CLASSIC
+    :hdr_histogram.log(ref, :classic, 'elixir.hgrm')
 
-        IO.puts "Done!"
-        end
+    # print other values
+    IO.puts "Min #{:hdr_histogram.min(ref)}"
+    IO.puts "Mean #{:hdr_histogram.mean(ref)}"
+    IO.puts "Median #{:hdr_histogram.median(ref)}"
+    IO.puts "Max #{:hdr_histogram.max(ref)}"
+    IO.puts "Stddev #{:hdr_histogram.stddev(ref)}"
+    IO.puts "99ile #{:hdr_histogram.percentile(ref,99.0)}"
+    IO.puts "99.9999ile #{:hdr_histogram.percentile(ref,99.9999)}"
+    IO.puts "Memory Size #{:hdr_histogram.get_memory_size(ref)}"
+    IO.puts "Total Count #{:hdr_histogram.get_total_count(ref)}"
+
+    # we're done, cleanup any held resources
+    :hdr_histogram.close(ref)
+
+    IO.puts "Done!"
+  end
+
+  def loop(_ref, 0), do: :ok
+  def loop(ref, x) do
+    :hdr_histogram.record(ref, :random.uniform(1000000))
+    loop(ref, x - 1)
+  end
 end
+
+Simple.main


### PR DESCRIPTION
The issue was, that the examples used a binary for file name in the usage of `hdr_histogram:log/3` (see http://elixir-lang.org/getting-started/binaries-strings-and-char-lists.html).

Since the usage of this library is not Elixir specific, I took the liberty of removing the example from the README. I hope that's okay.

I also applied common elixir code styles to the best of my knowledge.
