### PR TITLE
Fix building on linux

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -27,7 +27,7 @@ else ifeq ($(UNAME_SYS), FreeBSD)
 	CXXFLAGS ?= -O3 -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CFLAGS ?= -O3 -std=c99 -D_POSIX_C_SOURCE=199309L -finline-functions -Wall -Wmissing-prototypes
 	CXXFLAGS ?= -O3 -Wall
 endif
 


### PR DESCRIPTION
I am unsure if this is the proper fix to do, but without this change it fails for me with gcc 6.3.1 and glibc 2.25.

The actual error is:

```
hdr_histogram_erl/c_src/hdr_histogram_log.h:100:21:error: field ‘start_timestamp’ has incomplete type
struct timespec start_timestamp;
```