### PR TITLE
Resolve build failure

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -18,17 +18,17 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/hdr_histogram_nif.so
 UNAME_SYS := $(shell uname -s)
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS += -O3 -std=c99 -arch x86_64 -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -arch x86_64 -Wall
+	LDFLAGS += -arch x86_64 -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -Wall
+	CFLAGS += -O3 -std=c99 -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -Wall
 else ifeq ($(UNAME_SYS), Linux)
 	CC ?= gcc
-	CFLAGS ?= -O3 -std=c99 -D_POSIX_C_SOURCE=199309L -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -Wall
+	CFLAGS += -O3 -std=c99 -D_POSIX_C_SOURCE=199309L -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS += -O3 -Wall
 endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)

--- a/rebar.config
+++ b/rebar.config
@@ -37,9 +37,5 @@
     ]}
 ]}.
 
-{port_env, [
-  {"CFLAGS", "$CFLAGS -O3 -std=c99"}
-]}.
-
 {pre_hooks, [{"(linux|darwin|solaris)", compile, "make -C c_src"}]}.
 {post_hooks, [{"(linux|darwin|solaris)", clean, "make -C c_src clean"}]}.


### PR DESCRIPTION
If I understand it correctly, the `port_env` option in `rebar.config` specifies `-O3 -std=c99` for `CFLAGS`, but later in `c_src/Makefile` we do

```
else ifeq ($(UNAME_SYS), Linux)
    CC ?= gcc
    CFLAGS ?= -O3 -std=c99 -D_POSIX_C_SOURCE=199309L -finline-functions -Wall -Wmissing-prototypes
    CXXFLAGS ?= -O3 -Wall
endif
```
So `CFLAGS` is not updated since it has been defined.

I just use `+=` to append the platform-specific flags would be better and do not append the flags in `rebar.config`.

See #33 please.