### PR TITLE
add hex metadata and use git tag as version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+name: Common Test
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+  push:
+    branches:
+      - 'master'
+
+jobs:
+  build:
+    name: Test on OTP ${{ matrix.otp_version }} and ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        otp_version: [19, 20, 21, 22]
+        os: [ubuntu-latest]
+
+    container:
+      image: erlang:${{ matrix.otp_version }}
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Compile
+      run: rebar3 compile
+    - name: CT tests
+      run: rebar3 ct

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: erlang
-otp_release:
-  - 20.2
-  - 17.3
-  - 17.1
-  - 17.0
-install:
-  - wget https://s3.amazonaws.com/rebar3/rebar3 && chmod +x rebar3
-script: ./rebar3 ct

--- a/doc/edoc-info
+++ b/doc/edoc-info
@@ -1,4 +1,3 @@
 %% encoding: UTF-8
 {application,hdr_histogram}.
-{packages,[]}.
 {modules,[hdr_histogram,hdr_iter]}.

--- a/doc/hdr_histogram.md
+++ b/doc/hdr_histogram.md
@@ -6,14 +6,14 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 .
+
 Copyright (c) 2014 Darach Ennis
 
 __Version:__ 0.2.0
 
-
 __Authors:__ Darach Ennis ([`darach@gmail.com`](mailto:darach@gmail.com)).
+
 <a name="description"></a>
 
 ## Description ##
@@ -26,16 +26,12 @@ sampled data points across a configurable range with configurable precision
 within that range. The precision is expressed as a number of significant
 figures in the recording.
 
-
-
 This HDR histogram implementation is designed for recording histograms of
 value measurements in latency sensitive environments. Although the native
 recording times can be as low as single digit nanoseconds there is added
 overhead in this wrapper/binding due to both the frontend overhead of converting
 from native C to the NIF interface, and the erlang overhead incurred calling
 into the NIFs. C'est la vie, I suppose.
-
-
 
 A distinct advantage of this histogram implementation is constant space and
 recording (time) overhead with an ability to recycle and reset instances whilst
@@ -44,17 +40,11 @@ and garbage collection overhead in the BEAM where repeated or continuous usage
 is likely. For example, a gen_server recording metrics continuously and resetting
 and logging histogram dumps on a periodic or other windowed basis.
 
-
-
 The code is released to the public domain, under the same terms as its
 sibling projects, as explained in the LICENSE.txt and COPYING.txt in the
 root of this repository, but normatively at:
 
-
-
 http://creativecommons.org/publicdomain/zero/1.0/
-
-
 
 For users of this code who wish to consume it under the "BSD" license
 rather than under the public domain or CC0 contribution text mentioned
@@ -64,34 +54,23 @@ license does not detract from the above stated release of the code into
 the public domain, and simply represents an additional license granted by
 http://creativecommons.org/publicdomain/zero/1.0/
 
-
-
 -----------------------------------------------------------------------------
 ** Beginning of "BSD 2-Clause License" text. **
-
-
 
 Copyright (c) 2012, 2013, 2014 Gil Tene
 Copyright (c) 2014 Michael Barker
 Copyright (c) 2014 Darach Ennis
 All rights reserved.
 
-
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-
-
 
 1. Redistributions of source code must retain the above copyright notice,
 this list of conditions and the following disclaimer.
 
-
-
 2. Redistributions in binary form must reproduce the above copyright notice,
 this list of conditions and the following disclaimer in the documentation
 and/or other materials provided with the distribution.
-
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -115,21 +94,19 @@ THE POSSIBILITY OF SUCH DAMAGE.
 ### <a name="type-ref">ref()</a> ###
 
 
-
 <pre><code>
 ref() = binary()
 </code></pre>
 
+ NIF private data (looks like empty binary)
 
-
-  NIF private data (looks like empty binary)
 <a name="index"></a>
 
 ## Function Index ##
 
 
 <table width="100%" border="1" cellspacing="0" cellpadding="2" summary="function index"><tr><td valign="top"><a href="#add-2">add/2</a></td><td>Contribute the data points from a HDR histogram to another.</td></tr><tr><td valign="top"><a href="#close-1">close/1</a></td><td>Close this HDR histogram instance and free any system resources.</td></tr><tr><td valign="top"><a href="#count_at-2">count_at/2</a></td><td>Get the count of values at a given at a given value.</td></tr><tr><td valign="top"><a href="#from_binary-1">from_binary/1</a></td><td>Take a snapshot of HDR histogram internal state as a compressed binary and hydrate/open a reference.</td></tr><tr><td valign="top"><a href="#get_memory_size-1">get_memory_size/1</a></td><td>Get memory footprint of an HDR histogram.</td></tr><tr><td valign="top"><a href="#get_total_count-1">get_total_count/1</a></td><td>Get total count of record values.</td></tr><tr><td valign="top"><a href="#log-3">log/3</a></td><td>Log the histogram to a file in classic or CSV format.</td></tr><tr><td valign="top"><a href="#lowest_at-2">lowest_at/2</a></td><td>Get the lowest equivalent value.</td></tr><tr><td valign="top"><a href="#max-1">max/1</a></td><td>Get the maximum recorded data point value.</td></tr><tr><td valign="top"><a href="#mean-1">mean/1</a></td><td>Get the mean data point value to a significant figure.</td></tr><tr><td valign="top"><a href="#median-1">median/1</a></td><td>Get the median data point value to a significant figure.</td></tr><tr><td valign="top"><a href="#min-1">min/1</a></td><td>Get the minimum recorded data point value.</td></tr><tr><td valign="top"><a href="#open-2">open/2</a></td><td>Open a fresh instance of a high dynamic range (HDR) histogram.</td></tr><tr><td valign="top"><a href="#percentile-2">percentile/2</a></td><td>Get the specified percentile  data point value to a significant figure.</td></tr><tr><td valign="top"><a href="#print-2">print/2</a></td><td>Print the histogram to standard output in classic or CSV format.</td></tr><tr><td valign="top"><a href="#record-2">record/2</a></td><td>Record an uncorrected histogram data point value in a HDR histogram.</td></tr><tr><td valign="top"><a href="#record_corrected-3">record_corrected/3</a></td><td>Record a histogram data point value in a HDR histogram with
-expected interval for correction for coordinated ommission.</td></tr><tr><td valign="top"><a href="#record_many-3">record_many/3</a></td><td>Record a histogram data point value and number of occurances.</td></tr><tr><td valign="top"><a href="#reset-1">reset/1</a></td><td>Reset the memory backing this HDR histogram instance and zero results.</td></tr><tr><td valign="top"><a href="#same-3">same/3</a></td><td>Are two data point values considered to be equivalent.</td></tr><tr><td valign="top"><a href="#stddev-1">stddev/1</a></td><td>Get the standard deviation data point value to a significant figure.</td></tr><tr><td valign="top"><a href="#to_binary-1">to_binary/1</a></td><td>Take a snapshot of HDR histogram internal state as a compressed binary.</td></tr><tr><td valign="top"><a href="#to_binary-2">to_binary/2</a></td><td>Take a snapshot of HDR histogram internal state as an (optionally) compressed binary.</td></tr></table>
+expected interval for correction for coordinated ommission.</td></tr><tr><td valign="top"><a href="#record_many-3">record_many/3</a></td><td>Record a histogram data point value and number of occurances.</td></tr><tr><td valign="top"><a href="#reset-1">reset/1</a></td><td>Reset the memory backing this HDR histogram instance and zero results.</td></tr><tr><td valign="top"><a href="#rotate-2">rotate/2</a></td><td>Copy data from Ref to To and return the difference as binary.</td></tr><tr><td valign="top"><a href="#same-3">same/3</a></td><td>Are two data point values considered to be equivalent.</td></tr><tr><td valign="top"><a href="#stddev-1">stddev/1</a></td><td>Get the standard deviation data point value to a significant figure.</td></tr><tr><td valign="top"><a href="#to_binary-1">to_binary/1</a></td><td>Take a snapshot of HDR histogram internal state as a compressed binary.</td></tr><tr><td valign="top"><a href="#to_binary-2">to_binary/2</a></td><td>Take a snapshot of HDR histogram internal state as an (optionally) compressed binary.</td></tr></table>
 
 
 <a name="functions"></a>
@@ -140,18 +117,20 @@ expected interval for correction for coordinated ommission.</td></tr><tr><td val
 
 ### add/2 ###
 
-
 <pre><code>
 add(To, From) -&gt; integer() | {error, Reason}
 </code></pre>
 
 <ul class="definitions"><li><code>To = <a href="#type-ref">ref()</a></code></li><li><code>From = <a href="#type-ref">ref()</a></code></li><li><code>Reason = term()</code></li></ul>
 
-Contribute the data points from a HDR histogram to another. Return the number of dropped data point values. That is, the values from From that are higher than the HighestTrackableValue of To.
+Contribute the data points from a HDR histogram to another.
+Return the number of dropped data point values.
+That is, the values from `From` that are higher than the
+`HighestTrackableValue` of `To`.
+
 <a name="close-1"></a>
 
 ### close/1 ###
-
 
 <pre><code>
 close(Ref) -&gt; ok | {error, term()}
@@ -160,10 +139,10 @@ close(Ref) -&gt; ok | {error, term()}
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li></ul>
 
 Close this HDR histogram instance and free any system resources
+
 <a name="count_at-2"></a>
 
 ### count_at/2 ###
-
 
 <pre><code>
 count_at(Ref, Value) -&gt; CountAt
@@ -172,10 +151,10 @@ count_at(Ref, Value) -&gt; CountAt
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Value = integer()</code></li><li><code>CountAt = integer()</code></li></ul>
 
 Get the count of values at a given at a given value
+
 <a name="from_binary-1"></a>
 
 ### from_binary/1 ###
-
 
 <pre><code>
 from_binary(Binary) -&gt; {ok, Ref} | {error, term()}
@@ -184,10 +163,10 @@ from_binary(Binary) -&gt; {ok, Ref} | {error, term()}
 <ul class="definitions"><li><code>Binary = binary()</code></li><li><code>Ref = <a href="#type-ref">ref()</a></code></li></ul>
 
 Take a snapshot of HDR histogram internal state as a compressed binary and hydrate/open a reference. The reference SHOULD be closed when no longer needed to reclaim the memory used
+
 <a name="get_memory_size-1"></a>
 
 ### get_memory_size/1 ###
-
 
 <pre><code>
 get_memory_size(Ref) -&gt; Size
@@ -196,10 +175,10 @@ get_memory_size(Ref) -&gt; Size
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Size = integer()</code></li></ul>
 
 Get memory footprint of an HDR histogram
+
 <a name="get_total_count-1"></a>
 
 ### get_total_count/1 ###
-
 
 <pre><code>
 get_total_count(Ref) -&gt; Count
@@ -208,10 +187,10 @@ get_total_count(Ref) -&gt; Count
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Count = integer()</code></li></ul>
 
 Get total count of record values
+
 <a name="log-3"></a>
 
 ### log/3 ###
-
 
 <pre><code>
 log(Ref, Format, FileName::<a href="file.md#type-name">file:name()</a>) -&gt; ok | {error, Reason}
@@ -220,10 +199,10 @@ log(Ref, Format, FileName::<a href="file.md#type-name">file:name()</a>) -&gt; ok
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Format = classic | csv</code></li><li><code>Reason = term()</code></li></ul>
 
 Log the histogram to a file in classic or CSV format
+
 <a name="lowest_at-2"></a>
 
 ### lowest_at/2 ###
-
 
 <pre><code>
 lowest_at(Ref, Value) -&gt; LowestValueAt
@@ -232,10 +211,10 @@ lowest_at(Ref, Value) -&gt; LowestValueAt
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Value = integer()</code></li><li><code>LowestValueAt = float()</code></li></ul>
 
 Get the lowest equivalent value
+
 <a name="max-1"></a>
 
 ### max/1 ###
-
 
 <pre><code>
 max(Ref) -&gt; MaxValue
@@ -244,10 +223,10 @@ max(Ref) -&gt; MaxValue
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>MaxValue = integer()</code></li></ul>
 
 Get the maximum recorded data point value
+
 <a name="mean-1"></a>
 
 ### mean/1 ###
-
 
 <pre><code>
 mean(Ref) -&gt; MeanValue
@@ -256,10 +235,10 @@ mean(Ref) -&gt; MeanValue
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>MeanValue = float()</code></li></ul>
 
 Get the mean data point value to a significant figure
+
 <a name="median-1"></a>
 
 ### median/1 ###
-
 
 <pre><code>
 median(Ref) -&gt; MedianValue
@@ -268,10 +247,10 @@ median(Ref) -&gt; MedianValue
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>MedianValue = float()</code></li></ul>
 
 Get the median data point value to a significant figure
+
 <a name="min-1"></a>
 
 ### min/1 ###
-
 
 <pre><code>
 min(Ref) -&gt; MinValue
@@ -280,10 +259,10 @@ min(Ref) -&gt; MinValue
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>MinValue = integer()</code></li></ul>
 
 Get the minimum recorded data point value
+
 <a name="open-2"></a>
 
 ### open/2 ###
-
 
 <pre><code>
 open(HighestTrackableValue, SignificantFigures) -&gt; {ok, Ref} | {error, Reason}
@@ -292,10 +271,10 @@ open(HighestTrackableValue, SignificantFigures) -&gt; {ok, Ref} | {error, Reason
 <ul class="definitions"><li><code>HighestTrackableValue = integer()</code></li><li><code>SignificantFigures = 1..5</code></li><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Reason = term()</code></li></ul>
 
 Open a fresh instance of a high dynamic range (HDR) histogram
+
 <a name="percentile-2"></a>
 
 ### percentile/2 ###
-
 
 <pre><code>
 percentile(Ref, Percentile) -&gt; PercentileValue
@@ -304,10 +283,10 @@ percentile(Ref, Percentile) -&gt; PercentileValue
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Percentile = float()</code></li><li><code>PercentileValue = float()</code></li></ul>
 
 Get the specified percentile  data point value to a significant figure
+
 <a name="print-2"></a>
 
 ### print/2 ###
-
 
 <pre><code>
 print(Ref, Format) -&gt; ok | {error, Reason}
@@ -316,10 +295,10 @@ print(Ref, Format) -&gt; ok | {error, Reason}
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Format = classic | csv</code></li><li><code>Reason = term()</code></li></ul>
 
 Print the histogram to standard output in classic or CSV format
+
 <a name="record-2"></a>
 
 ### record/2 ###
-
 
 <pre><code>
 record(Ref, Value) -&gt; ok | {error, Reason}
@@ -328,10 +307,10 @@ record(Ref, Value) -&gt; ok | {error, Reason}
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Value = integer()</code></li><li><code>Reason = term()</code></li></ul>
 
 Record an uncorrected histogram data point value in a HDR histogram
+
 <a name="record_corrected-3"></a>
 
 ### record_corrected/3 ###
-
 
 <pre><code>
 record_corrected(Ref, Value, ExpectedInterval) -&gt; ok | {error, Reason}
@@ -341,10 +320,10 @@ record_corrected(Ref, Value, ExpectedInterval) -&gt; ok | {error, Reason}
 
 Record a histogram data point value in a HDR histogram with
 expected interval for correction for coordinated ommission
+
 <a name="record_many-3"></a>
 
 ### record_many/3 ###
-
 
 <pre><code>
 record_many(Ref, Value, Count) -&gt; ok | {error, Reason}
@@ -353,10 +332,10 @@ record_many(Ref, Value, Count) -&gt; ok | {error, Reason}
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Value = integer()</code></li><li><code>Count = integer()</code></li><li><code>Reason = term()</code></li></ul>
 
 Record a histogram data point value and number of occurances
+
 <a name="reset-1"></a>
 
 ### reset/1 ###
-
 
 <pre><code>
 reset(Ref) -&gt; ok | {error, term()}
@@ -365,10 +344,22 @@ reset(Ref) -&gt; ok | {error, term()}
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li></ul>
 
 Reset the memory backing this HDR histogram instance and zero results
+
+<a name="rotate-2"></a>
+
+### rotate/2 ###
+
+<pre><code>
+rotate(Ref, To) -&gt; Diff::binary() | {error, term()}
+</code></pre>
+
+<ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>To = <a href="#type-ref">ref()</a></code></li></ul>
+
+Copy data from Ref to To and return the difference as binary
+
 <a name="same-3"></a>
 
 ### same/3 ###
-
 
 <pre><code>
 same(Ref, A, B) -&gt; AreEquivalent
@@ -377,10 +368,10 @@ same(Ref, A, B) -&gt; AreEquivalent
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>A = integer()</code></li><li><code>B = integer()</code></li><li><code>AreEquivalent = boolean()</code></li></ul>
 
 Are two data point values considered to be equivalent
+
 <a name="stddev-1"></a>
 
 ### stddev/1 ###
-
 
 <pre><code>
 stddev(Ref) -&gt; StddevValue
@@ -389,10 +380,10 @@ stddev(Ref) -&gt; StddevValue
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>StddevValue = float()</code></li></ul>
 
 Get the standard deviation data point value to a significant figure
+
 <a name="to_binary-1"></a>
 
 ### to_binary/1 ###
-
 
 <pre><code>
 to_binary(Ref) -&gt; binary() | {error, term()}
@@ -401,10 +392,10 @@ to_binary(Ref) -&gt; binary() | {error, term()}
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li></ul>
 
 Take a snapshot of HDR histogram internal state as a compressed binary. The reference HDR instance can be modified after a snapshot is taken in the usual way with no restrictions.
+
 <a name="to_binary-2"></a>
 
 ### to_binary/2 ###
-
 
 <pre><code>
 to_binary(Ref, X2::[{compression, none} | {compression, zlib}]) -&gt; binary() | {error, term()}
@@ -413,3 +404,4 @@ to_binary(Ref, X2::[{compression, none} | {compression, zlib}]) -&gt; binary() |
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li></ul>
 
 Take a snapshot of HDR histogram internal state as an (optionally) compressed binary. The reference HDR instance can be modified after a snapshot is taken in the usual way with no restrictions.
+

--- a/doc/hdr_iter.md
+++ b/doc/hdr_iter.md
@@ -6,14 +6,14 @@
 * [Function Index](#index)
 * [Function Details](#functions)
 
-
 .
+
 Copyright (c) 2014 Darach Ennis
 
 __Version:__ 0.2.0
 
-
 __Authors:__ Darach Ennis ([`darach@gmail.com`](mailto:darach@gmail.com)).
+
 <a name="description"></a>
 
 ## Description ##
@@ -26,16 +26,12 @@ sampled data points across a configurable range with configurable precision
 within that range. The precision is expressed as a number of significant
 figures in the recording.
 
-
-
 This HDR histogram implementation is designed for recording histograms of
 value measurements in latency sensitive environments. Although the native
 recording times can be as low as single digit nanoseconds there is added
 overhead in this wrapper/binding due to both the frontend overhead of converting
 from native C to the NIF interface, and the erlang overhead incurred calling
 into the NIFs. C'est la vie, I suppose.
-
-
 
 A distinct advantage of this histogram implementation is constant space and
 recording (time) overhead with an ability to recycle and reset instances whilst
@@ -44,17 +40,11 @@ and garbage collection overhead in the BEAM where repeated or continuous usage
 is likely. For example, a gen_server recording metrics continuously and resetting
 and logging histogram dumps on a periodic or other windowed basis.
 
-
-
 The code is released to the public domain, under the same terms as its
 sibling projects, as explained in the LICENSE.txt and COPYING.txt in the
 root of this repository, but normatively at:
 
-
-
 http://creativecommons.org/publicdomain/zero/1.0/
-
-
 
 For users of this code who wish to consume it under the "BSD" license
 rather than under the public domain or CC0 contribution text mentioned
@@ -64,34 +54,23 @@ license does not detract from the above stated release of the code into
 the public domain, and simply represents an additional license granted by
 http://creativecommons.org/publicdomain/zero/1.0/
 
-
-
 -----------------------------------------------------------------------------
 ** Beginning of "BSD 2-Clause License" text. **
-
-
 
 Copyright (c) 2012, 2013, 2014 Gil Tene
 Copyright (c) 2014 Michael Barker
 Copyright (c) 2014 Darach Ennis
 All rights reserved.
 
-
-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
-
-
 
 1. Redistributions of source code must retain the above copyright notice,
 this list of conditions and the following disclaimer.
 
-
-
 2. Redistributions in binary form must reproduce the above copyright notice,
 this list of conditions and the following disclaimer in the documentation
 and/or other materials provided with the distribution.
-
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
@@ -115,14 +94,12 @@ THE POSSIBILITY OF SUCH DAMAGE.
 ### <a name="type-ref">ref()</a> ###
 
 
-
 <pre><code>
 ref() = binary()
 </code></pre>
 
+ NIF private data (looks like empty binary)
 
-
-  NIF private data (looks like empty binary)
 <a name="index"></a>
 
 ## Function Index ##
@@ -139,7 +116,6 @@ ref() = binary()
 
 ### close/1 ###
 
-
 <pre><code>
 close(Ref) -&gt; ok | {error, term()}
 </code></pre>
@@ -147,10 +123,10 @@ close(Ref) -&gt; ok | {error, term()}
 <ul class="definitions"><li><code>Ref = <a href="#type-ref">ref()</a></code></li></ul>
 
 Close this HDR histogram instance and free any system resources
+
 <a name="each-2"></a>
 
 ### each/2 ###
-
 
 <pre><code>
 each(IteratorRef, EachFun) -&gt; ok | {error, Reason}
@@ -159,10 +135,10 @@ each(IteratorRef, EachFun) -&gt; ok | {error, Reason}
 <ul class="definitions"><li><code>EachFun = fun((Data) -&gt; any())</code></li><li><code>IteratorRef = <a href="#type-ref">ref()</a></code></li><li><code>Data = term()</code></li><li><code>Reason = term()</code></li></ul>
 
 Iterate over histogram applying a function to each data point
+
 <a name="each-3"></a>
 
 ### each/3 ###
-
 
 <pre><code>
 each(IteratorRef, EachFun, Initial) -&gt; {ok, Accum} | {error, Reason}
@@ -171,10 +147,10 @@ each(IteratorRef, EachFun, Initial) -&gt; {ok, Accum} | {error, Reason}
 <ul class="definitions"><li><code>EachFun = fun(({IteratorType, Data}, Acc) -&gt; any())</code></li><li><code>IteratorType = record | linear | logarithmic | percentile</code></li><li><code>Data = [{atom(), term()}]</code></li><li><code>Acc = term()</code></li><li><code>IteratorRef = <a href="#type-ref">ref()</a></code></li><li><code>Reason = term()</code></li><li><code>Initial = term()</code></li><li><code>Accum = term()</code></li></ul>
 
 Iterate over histogram applying a function to each data point accumulating a result
+
 <a name="open-3"></a>
 
 ### open/3 ###
-
 
 <pre><code>
 open(IterationType, HdrRef, Options) -&gt; {ok, Ref} | {error, Reason}
@@ -183,3 +159,4 @@ open(IterationType, HdrRef, Options) -&gt; {ok, Ref} | {error, Reason}
 <ul class="definitions"><li><code>IterationType = record | linear | logarithmic | percentile</code></li><li><code>HdrRef = <a href="#type-ref">ref()</a></code></li><li><code>Ref = <a href="#type-ref">ref()</a></code></li><li><code>Options = [<a href="proplists.md#type-property">proplists:property()</a>]</code></li><li><code>Reason = term()</code></li></ul>
 
 Open a fresh instance of a high dynamic range (HDR) histogram iterator
+

--- a/rebar.config
+++ b/rebar.config
@@ -13,7 +13,7 @@
     warnings_as_errors
 ]}.
 
-{profiles, [{docs, [{deps, [{edown, {git, "https://github.com/uwiger/edown.git", {tag, "0.8"}}}]},
+{profiles, [{docs, [{deps, [edown]},
                     {edoc_opts, [
                                  {report_missing_types, true},
                                  {doclet, edown_doclet},

--- a/rebar.config
+++ b/rebar.config
@@ -28,7 +28,7 @@
 
 {pre_hooks,
    [{"(linux|darwin|solaris)", compile, "make -C c_src"},
-       {"(freebsd)", compile, "gmake -C c_src"}]}.
+    {"(freebsd)", compile, "gmake -C c_src"}]}.
 {post_hooks,
-   [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
-       {"(freebsd)", clean, "gmake -C c_src clean"}]}.
+ [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
+  {"(freebsd)", clean, "gmake -C c_src clean"}]}.

--- a/src/hdr_histogram.app.src
+++ b/src/hdr_histogram.app.src
@@ -8,9 +8,12 @@
 {application, hdr_histogram,
  [
   {description, "High Dynamic Range Histogram Erlang/OTP library"},
-  {vsn, "0.2.0"},
+  {vsn, git},
   {modules, [ hdr_histogram ]},
   {registered, []},
   {applications, [ kernel, stdlib ]},
-  {env, []}
+  {env, []},
+
+  {licenses, ["BSD-2-Clause"]},
+  {links, [{"GitHub", "https://github.com/HdrHistogram/hdr_histogram_erl"}]}
  ]}.

--- a/test/hdr_histogram_SUITE.erl
+++ b/test/hdr_histogram_SUITE.erl
@@ -389,6 +389,6 @@ load(N,{Raw,Cor}) ->
 
 cmp(L1,L2,D) ->
     case erlang:abs(L1-L2) < D of
-	false -> throw({not_same, L1, L2, D, erlang:get_stacktrace()});
+	false -> throw({not_same, L1, L2, D});
 	true -> true
     end.


### PR DESCRIPTION
Adding a link to the source and the license to the hex metadata and using `git` for `vsn`. The version had gotten out of sync with the tags at this point so this resolves that issue.