### PR TITLE
Use rebar "pc" plugin for portable compilation

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -26,9 +26,15 @@
                                 ]}]},
             {test, [{deps, [{fqc, {git, "https://github.com/project-fifo/fqc.git", {branch, "master"}}}]}]}]}.
 
-{pre_hooks,
-   [{"(linux|darwin|solaris)", compile, "make -C c_src"},
-    {"(freebsd)", compile, "gmake -C c_src"}]}.
-{post_hooks,
- [{"(linux|darwin|solaris)", clean, "make -C c_src clean"},
-  {"(freebsd)", clean, "gmake -C c_src clean"}]}.
+{plugins, [pc]}.
+
+{provider_hooks,
+ [
+  {pre,
+   [
+    {compile, {pc, compile}},
+    {clean, {pc, clean}}
+   ]
+  }
+ ]
+}.


### PR DESCRIPTION
Fixes builds from source on systems with non-GNU make or other unlisted operating systems