### PR TITLE
Support Mac M1 / arm64 architecture

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -15,11 +15,18 @@ C_SRC_OUTPUT ?= $(CURDIR)/../priv/$(PROJECT).so
 # System type and C compiler/flags.
 
 UNAME_SYS := $(shell uname -s)
+UNAME_ARCH := $(shell uname -p)
+
+ARCH := x86_64
+ifeq ($(UNAME_ARCH), arm)
+	ARCH := arm64
+endif
+
 ifeq ($(UNAME_SYS), Darwin)
 	CC ?= cc
-	CFLAGS ?= -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes
-	CXXFLAGS ?= -O3 -arch x86_64 -finline-functions -Wall
-	LDFLAGS ?= -arch x86_64 -flat_namespace -undefined suppress
+	CFLAGS ?= -O3 -std=c99 -arch $(ARCH) -finline-functions -Wall -Wmissing-prototypes
+	CXXFLAGS ?= -O3 -arch $(ARCH) -finline-functions -Wall
+	LDFLAGS ?= -arch $(ARCH) -flat_namespace -undefined suppress
 else ifeq ($(UNAME_SYS), FreeBSD)
 	CC ?= clang
 	CFLAGS ?= -O3 -std=c99 -Wall -Wmissing-prototypes


### PR DESCRIPTION
This commit updates the Makefile for the C source code to check
the architecture via `uname -p` before initializing the compiler
flags. Mac M1s will report `arm` architecture, and in that case
we change the cc flags from `x86_64` to `arm64`. Prior to this
patch, trying to use this library on an m1 causes an error.
With the patch, it runs properly.
